### PR TITLE
Add micro_wake_word external component override from ESPHome PR #15628

### DIFF
--- a/config/common/respeaker-satellite-base.yaml
+++ b/config/common/respeaker-satellite-base.yaml
@@ -1347,6 +1347,12 @@ external_components:
       ref: ff8ce89556748509d7ee8724e12d9d43d3c8c1e8
     refresh: 0s
     components: [http_request]
+  - source: github://pr#15628
+    # Workaround for "Failed to allocate tensors for the streaming model":
+    # https://github.com/esphome/esphome/issues/15603#issuecomment-4224931948
+    refresh: 0s
+    components:
+      - micro_wake_word
 
 audio_dac:
   - platform: aic3204


### PR DESCRIPTION
## Summary

This change adds an `external_components` override for `micro_wake_word` from ESPHome PR #15628.

## Reason

This is a workaround for the following runtime error:

`Failed to allocate tensors for the streaming model`

Reference:
https://github.com/esphome/esphome/issues/15603

## Change

```yaml
- source: github://pr#15628
  refresh: 0s
  components:
    - micro_wake_word
